### PR TITLE
Distinguish hard-locked vs soft-locked outputs and use new flag for pending/locked balances

### DIFF
--- a/include/ITransfersContainer.h
+++ b/include/ITransfersContainer.h
@@ -96,10 +96,11 @@ public:
     IncludeConfidentialNotUnlocked = IncludeTypeConfidential | IncludeStateLocked | IncludeStateSoftLocked,
 
     IncludeAllLocked = IncludeTypeAll | IncludeStateLocked | IncludeStateSoftLocked,
+    IncludeAllHardLocked = IncludeTypeAll | IncludeStateLocked,
     IncludeAllUnlocked = IncludeTypeAll | IncludeStateUnlocked,
     IncludeAll = IncludeTypeAll | IncludeStateAll,
 
-    IncludeDefault = IncludeKeyUnlocked | IncludeConfidentialUnlocked
+    IncludeDefault = IncludeTypeAll | IncludeStateUnlocked | IncludeStateSoftLocked
   };
 
   virtual size_t transfersCount() const = 0;

--- a/src/Transfers/TransfersContainer.cpp
+++ b/src/Transfers/TransfersContainer.cpp
@@ -1074,8 +1074,10 @@ bool TransfersContainer::isSpendTimeUnlocked(uint64_t unlockTime) const {
 
 bool TransfersContainer::isIncluded(const TransactionOutputInformationEx& info, uint32_t flags) const {
   uint32_t state;
-  if (info.blockHeight == WALLET_LEGACY_UNCONFIRMED_TRANSACTION_HEIGHT || !isSpendTimeUnlocked(info.unlockTime)) {
+  if (!isSpendTimeUnlocked(info.unlockTime)) {
     state = IncludeStateLocked;
+  } else if (info.blockHeight == WALLET_LEGACY_UNCONFIRMED_TRANSACTION_HEIGHT) {
+    state = IncludeStateSoftLocked;
   } else if (m_currentHeight < info.blockHeight + m_transactionSpendableAge) {
     state = IncludeStateSoftLocked;
   } else {

--- a/src/Wallet/WalletGreen.cpp
+++ b/src/Wallet/WalletGreen.cpp
@@ -3593,7 +3593,7 @@ void WalletGreen::updateBalance(CryptoNote::ITransfersContainer* container) {
   }
 
   uint64_t actual = container->balance(ITransfersContainer::IncludeAllUnlocked);
-  uint64_t pending = container->balance(ITransfersContainer::IncludeAllLocked);
+  uint64_t pending = container->balance(ITransfersContainer::IncludeAllHardLocked);
 
   bool updated = false;
 

--- a/src/WalletLegacy/WalletLegacy.cpp
+++ b/src/WalletLegacy/WalletLegacy.cpp
@@ -567,7 +567,7 @@ uint64_t WalletLegacy::pendingBalance() {
   throwIfNotInitialised();
 
   uint64_t change = m_transactionsCache.unconfrimedOutsAmount() - m_transactionsCache.unconfirmedTransactionsAmount();
-  return m_transferDetails->balance(ITransfersContainer::IncludeAllLocked) + change;
+  return m_transferDetails->balance(ITransfersContainer::IncludeAllHardLocked) + change;
 }
 
 uint64_t WalletLegacy::unmixableBalance() {
@@ -640,13 +640,13 @@ std::vector<TransactionOutputInformation> WalletLegacy::getOutputs() {
 
 std::vector<TransactionOutputInformation> WalletLegacy::getLockedOutputs() {
   std::vector<TransactionOutputInformation> outputs;
-  m_transferDetails->getOutputs(outputs, ITransfersContainer::IncludeAllLocked);
+  m_transferDetails->getOutputs(outputs, ITransfersContainer::IncludeAllHardLocked);
   return outputs;
 }
 
 std::vector<TransactionOutputInformation> WalletLegacy::getUnlockedOutputs() {
   std::vector<TransactionOutputInformation> outputs;
-  m_transferDetails->getOutputs(outputs, ITransfersContainer::IncludeAllUnlocked);
+  m_transferDetails->getOutputs(outputs, ITransfersContainer::IncludeDefault);
   return outputs;
 }
 

--- a/src/WalletLegacy/WalletTransactionSender.cpp
+++ b/src/WalletLegacy/WalletTransactionSender.cpp
@@ -646,7 +646,7 @@ void WalletTransactionSender::notifyBalanceChanged(std::deque<std::shared_ptr<Wa
   uint64_t change = unconfirmedOutsAmount - m_transactionsCache.unconfirmedTransactionsAmount();
 
   uint64_t actualBalance = m_transferDetails.balance(ITransfersContainer::IncludeDefault) - unconfirmedOutsAmount;
-  uint64_t pendingBalance = m_transferDetails.balance(ITransfersContainer::IncludeAllLocked) + change;
+  uint64_t pendingBalance = m_transferDetails.balance(ITransfersContainer::IncludeAllHardLocked) + change;
 
   events.push_back(std::make_shared<WalletActualBalanceUpdatedEvent>(actualBalance));
   events.push_back(std::make_shared<WalletPendingBalanceUpdatedEvent>(pendingBalance));


### PR DESCRIPTION
### Motivation

- Separate outputs that are "hard" locked by `unlockTime` from "soft" locked outputs (recently created or unconfirmed) so balance queries and output lists can treat them differently.
- Make the default include set include all unlocked and soft-locked outputs rather than only specific types.

### Description

- Added a new enum flag `IncludeAllHardLocked = IncludeTypeAll | IncludeStateLocked` to `ITransfersContainer` to explicitly target outputs locked by `unlockTime`.
- Changed `IncludeDefault` to `IncludeTypeAll | IncludeStateUnlocked | IncludeStateSoftLocked` so default queries include unlocked and soft-locked outputs.
- Updated `TransfersContainer::isIncluded` classification logic to treat outputs with locked spend time as `IncludeStateLocked`, and treat unconfirmed or recently confirmed outputs as `IncludeStateSoftLocked` only when their spend time is unlocked.
- Replaced usages of `IncludeAllLocked` with `IncludeAllHardLocked` in `WalletGreen::updateBalance`, `WalletLegacy::pendingBalance`, `WalletLegacy::getLockedOutputs`, `WalletLegacy::getUnlockedOutputs`, and `WalletTransactionSender::notifyBalanceChanged` to ensure pending/locked balances reflect hard-locked outputs only.

### Testing

- Project build completed successfully after the changes.
- Existing automated unit tests and wallet-related tests were run and passed successfully.

