### PR TITLE
Harden mempool pubkey index: reject collisions and widen outIdx to uint32 for CT ring resolution

### DIFF
--- a/docs/ct_master_review.md
+++ b/docs/ct_master_review.md
@@ -1,0 +1,96 @@
+# Confidential Transactions (Pubkey-Referenced Rings) Review vs Master
+
+Date: 2026-05-01
+Branch under review: `work`
+Head reviewed: `89b1950` (feature) + `154c2bb` (review artifact)
+Master baseline used: merge point `80c2bac` (explicit `Merge branch 'master' into dev/ct_15` in history).
+
+## Executive summary
+
+- **Architecture direction is correct**: ring-member references by output pubkey are significantly more reorg-robust than global index references.
+- **Consensus safety posture is good**: block validation is chain-only (`allowMempool=false`), so mempool state cannot alter consensus decisions.
+- **Critical hardening needed (now implemented in this branch)**:
+  1. reject mempool pubkey-index collisions instead of silently overwriting,
+  2. widen mempool output index type from `uint16_t` to `uint32_t`.
+- **Remaining requirement before production**: targeted regression/integration tests for mempool chaining, cascade eviction, reorg transitions, and collision handling.
+
+## Review method and coverage
+
+The following implementation areas were reviewed end-to-end:
+
+1. **Transaction model and serialization**
+   - `ConfidentialInput` schema and wire encoding for pubkey-based ring members.
+2. **Core/consensus validation**
+   - ring invariants, binding of pubkey/commitment pairs, and signature sizing checks.
+3. **Blockchain storage/indexing**
+   - LMDB pubkey index lifecycle: insert, lookup, rollback/remove.
+4. **Mempool policy and dependency handling**
+   - pubkey fallback resolution, ancestor handling, and cascade removals.
+5. **Wallet construction/signing path**
+   - ring sorting and `realIndex` remapping before CT signing.
+6. **Explorer/RPC-facing CT fields**
+   - mixin and CT visibility touchpoints impacted by ring representation changes.
+
+## Findings
+
+### A) Consensus and chain validation: strong
+
+- `ConfidentialInput` ring members are now pubkey-referenced and commitments are aligned by index.
+- Consensus checks validate ring non-emptiness, size consistency, and strict lexicographic ordering of pubkeys.
+- Signature vector sizing is validated against ring size.
+- Block-path CT validation remains chain-only (no mempool fallback), preserving deterministic consensus behavior.
+
+### B) Storage/indexing: strong with clear rollback model
+
+- LMDB pubkey index (`output_pubkey_idx`) provides stable output identity independent of global positional indexes.
+- Connect/disconnect paths include insertion/removal hooks for pubkey index entries.
+
+### C) Mempool fallback/chaining: good design, two concrete hardening issues were present
+
+#### C1) Collision policy in mempool pubkey index (**fixed in this branch**)
+
+Previous behavior: “last writer wins” overwrite in `m_pubkey_to_output`.
+
+Risk: if duplicate output pubkeys appear in pool state, a dependent tx could resolve to wrong parent output.
+
+Fix implemented:
+- Duplicate pubkey inside same tx => reject.
+- Duplicate pubkey already indexed by different tx => reject.
+- On rejection, pool insertion is rolled back (spent-key-image insertions and tx indices removed).
+
+#### C2) `uint16_t` output index in mempool lookup (**fixed in this branch**)
+
+Previous behavior: mempool output index was stored and returned as `uint16_t`.
+
+Risk: potential truncation boundary at >65535 outputs.
+
+Fix implemented:
+- Mempool pubkey index now stores `uint32_t` output index.
+- Lookup APIs updated accordingly.
+- CT resolver uses separate mempool index variable (`uint32_t`) and safe size checks.
+
+## Files changed for fixes
+
+- `src/CryptoNoteCore/TransactionPool.h`
+- `src/CryptoNoteCore/TransactionPool.cpp`
+- `src/CryptoNoteCore/Blockchain.cpp`
+
+## Production readiness
+
+Current status after fixes:
+- **Consensus path**: acceptable.
+- **Mempool chaining policy**: materially improved and safer.
+- **Not yet production-ready until tests below pass**.
+
+## Required test plan before production
+
+1. **Mempool chain resolution**: A->B where B references A outputs via ring pubkeys.
+2. **Cascade eviction**: remove A and ensure B/C descendants are evicted in dependency order.
+3. **Parent mined transition**: mine A while B remains in pool; B revalidates via chain index.
+4. **Reorg cycle**: A mined -> reorg out -> back in; ensure resolver/index remains consistent.
+5. **Collision rejection**: inject or craft duplicate output pubkey attempts; verify deterministic rejection and rollback.
+6. **Boundary index test**: stress output indexing behavior with large output counts (policy/limits permitting).
+
+## Final verdict
+
+The CT pubkey-referenced ring migration is directionally sound and addresses the core reorg fragility of index-referenced rings. With the implemented mempool collision/type fixes and the required regression suite, this implementation can move from integration-hardening to production candidacy.

--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -2364,6 +2364,7 @@ bool Blockchain::checkConfidentialTransaction(const Transaction& tx, const Crypt
       uint32_t block = 0;
       uint16_t txSlot = 0;
       uint16_t outIdx = 0;
+      uint32_t mempoolOutIdx = 0;
       bool fromMempool = false;
       Transaction mempoolTx;  // populated only when fromMempool
 
@@ -2374,7 +2375,7 @@ bool Blockchain::checkConfidentialTransaction(const Transaction& tx, const Crypt
           return false;
         }
         Crypto::Hash mempoolTxHash;
-        if (!m_tx_pool.findOutputByPubkey(cin.ringPubkeys[k], mempoolTxHash, outIdx)) {
+        if (!m_tx_pool.findOutputByPubkey(cin.ringPubkeys[k], mempoolTxHash, mempoolOutIdx)) {
           logger(ERROR) << "CT validation: input " << i << " failed to resolve ring member " << k
                         << " by pubkey (chain or mempool) in tx " << txHash;
           return false;
@@ -2385,7 +2386,7 @@ bool Blockchain::checkConfidentialTransaction(const Transaction& tx, const Crypt
                         << " gone between resolve and fetch (race), in tx " << txHash;
           return false;
         }
-        if (outIdx >= mempoolTx.outputs.size()) {
+        if (mempoolOutIdx >= mempoolTx.outputs.size()) {
           logger(ERROR) << "CT validation: input " << i << " resolved mempool ring member " << k
                         << " with invalid output index in tx " << txHash;
           return false;
@@ -2414,7 +2415,9 @@ bool Blockchain::checkConfidentialTransaction(const Transaction& tx, const Crypt
         return false;
       }
 
-      const auto& referencedOutput = sourceTx->outputs[outIdx];
+      const size_t resolvedOutIdx = fromMempool ? static_cast<size_t>(mempoolOutIdx)
+                                                : static_cast<size_t>(outIdx);
+      const auto& referencedOutput = sourceTx->outputs[resolvedOutIdx];
       const bool ringMemberIsKey = referencedOutput.target.type() == typeid(KeyOutput);
       const bool ringMemberIsConfidential = referencedOutput.target.type() == typeid(ConfidentialOutput);
       if (!ringMemberIsKey && !ringMemberIsConfidential) {

--- a/src/CryptoNoteCore/TransactionPool.cpp
+++ b/src/CryptoNoteCore/TransactionPool.cpp
@@ -250,7 +250,19 @@ namespace CryptoNote {
 
     // Phase 2: index this tx's output pubkeys so the CT validator can resolve
     // ring members that point to mempool-only outputs (zero-conf chaining).
-    addTransactionOutputsToPubkeyIndex(id, tx);
+    if (!addTransactionOutputsToPubkeyIndex(id, tx)) {
+      removeTransactionInputs(id, tx, keptByBlock);
+      auto txIt = m_transactions.find(id);
+      if (txIt != m_transactions.end()) {
+        m_paymentIdIndex.remove(txIt->tx);
+        m_timestampIndex.remove(txIt->receiveTime, txIt->id);
+        m_transactions.erase(txIt);
+      }
+      tvc.m_added_to_pool = false;
+      tvc.m_verification_failed = true;
+      logger(INFO) << "tx has duplicate output pubkey collision in mempool index, rejected";
+      return false;
+    }
 
     tvc.m_verification_failed = false;
     //succeed
@@ -895,7 +907,8 @@ namespace CryptoNote {
   }
 
   //---------------------------------------------------------------------------------
-  void tx_memory_pool::addTransactionOutputsToPubkeyIndex(const Crypto::Hash& id, const Transaction& tx) {
+  bool tx_memory_pool::addTransactionOutputsToPubkeyIndex(const Crypto::Hash& id, const Transaction& tx) {
+    std::unordered_set<Crypto::PublicKey> seenInTx;
     for (size_t o = 0; o < tx.outputs.size(); ++o) {
       Crypto::PublicKey pk;
       if (tx.outputs[o].target.type() == typeid(KeyOutput)) {
@@ -905,10 +918,22 @@ namespace CryptoNote {
       } else {
         continue;
       }
-      // Last writer wins on collision (shouldn't happen with valid txs since
-      // pubkey uniqueness is enforced at chain level via key-image rules).
-      m_pubkey_to_output[pk] = std::make_pair(id, static_cast<uint16_t>(o));
+      if (!seenInTx.insert(pk).second) {
+        logger(ERROR) << "Duplicate output pubkey inside transaction " << id
+                      << " at output index " << o;
+        return false;
+      }
+
+      auto it = m_pubkey_to_output.find(pk);
+      if (it != m_pubkey_to_output.end() && it->second.first != id) {
+        logger(ERROR) << "Output pubkey collision in mempool index for tx " << id
+                      << " collides with tx " << it->second.first;
+        return false;
+      }
+
+      m_pubkey_to_output[pk] = std::make_pair(id, static_cast<uint32_t>(o));
     }
+    return true;
   }
 
   //---------------------------------------------------------------------------------
@@ -928,7 +953,7 @@ namespace CryptoNote {
 
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::findOutputByPubkey(const Crypto::PublicKey& pubkey,
-                                            Crypto::Hash& txHash, uint16_t& outIdx) const {
+                                            Crypto::Hash& txHash, uint32_t& outIdx) const {
     std::lock_guard<std::recursive_mutex> lock(m_transactions_lock);
     auto it = m_pubkey_to_output.find(pubkey);
     if (it == m_pubkey_to_output.end()) {

--- a/src/CryptoNoteCore/TransactionPool.h
+++ b/src/CryptoNoteCore/TransactionPool.h
@@ -130,7 +130,7 @@ namespace CryptoNote {
     // outputs (zero-conf chaining). Returns false if no mempool tx contributes
     // an output with the requested target pubkey.
     bool findOutputByPubkey(const Crypto::PublicKey& pubkey,
-                            Crypto::Hash& txHash, uint16_t& outIdx) const;
+                            Crypto::Hash& txHash, uint32_t& outIdx) const;
 
     template<class t_ids_container, class t_tx_container, class t_missed_container>
     void getTransactions(const t_ids_container& txsIds, t_tx_container& txs, t_missed_container& missedTxs) {
@@ -203,7 +203,7 @@ namespace CryptoNote {
     bool removeTransactionInputs(const Crypto::Hash& id, const Transaction& tx, bool keptByBlock);
 
     // Phase 2: track output pubkeys of mempool txs for zero-conf ring resolution.
-    void addTransactionOutputsToPubkeyIndex(const Crypto::Hash& id, const Transaction& tx);
+    bool addTransactionOutputsToPubkeyIndex(const Crypto::Hash& id, const Transaction& tx);
     void removeTransactionOutputsFromPubkeyIndex(const Transaction& tx);
 
     // Phase 2: walk a candidate tx's CT input ring members; for each member that
@@ -248,7 +248,7 @@ namespace CryptoNote {
     // Phase 2: maps a target pubkey of a mempool tx output to (txHash, outIdx).
     // Used by the CT validator to resolve ring members that reference outputs
     // not yet committed to chain. Protected by m_transactions_lock.
-    std::unordered_map<Crypto::PublicKey, std::pair<Crypto::Hash, uint16_t>> m_pubkey_to_output;
+    std::unordered_map<Crypto::PublicKey, std::pair<Crypto::Hash, uint32_t>> m_pubkey_to_output;
 
     Logging::LoggerRef logger;
 
@@ -256,4 +256,3 @@ namespace CryptoNote {
     TimestampTransactionsIndex m_timestampIndex;
   };
 }
-


### PR DESCRIPTION
### Motivation

- Improve mempool-based Confidential Transactions (CT) ring resolution safety by preventing silent pubkey-index overwrites that could cause incorrect parent resolution.
- Prevent output index truncation for mempool-resolved outputs by expanding the stored index width beyond `uint16_t` to support large output counts.

### Description

- Changed mempool pubkey index type from `uint16_t` to `uint32_t` and updated APIs: `tx_memory_pool::findOutputByPubkey` signature and the `m_pubkey_to_output` map key/value types in `TransactionPool.h` and usages in `TransactionPool.cpp` and `Blockchain.cpp` were updated to use `uint32_t` for mempool output indices.
- Added collision detection when indexing a transaction's outputs in `tx_memory_pool::addTransactionOutputsToPubkeyIndex` to reject duplicate output pubkeys within the same transaction and to reject collisions with existing mempool entries, returning `false` on detection and logging an error.
- Converted `addTransactionOutputsToPubkeyIndex` to return `bool` and wired failure handling in `tx_memory_pool::add_tx` to roll back previously added inputs and indices and to reject the transaction on pubkey collisions, logging the rejection.
- Updated CT validation in `Blockchain::checkConfidentialTransaction` to use a distinct `mempoolOutIdx` (`uint32_t`) for mempool lookups and to resolve the correct output index (`resolvedOutIdx`) when selecting the referenced output.
- Implemented per-tx duplicate-pubkey detection using a local `seenInTx` set and ensured `removeTransactionOutputsFromPubkeyIndex` continues to erase entries correctly.

### Testing

- No automated tests were executed as part of this rollout; a targeted automated test plan is recommended and outlined in the added review document `docs/ct_master_review.md` and includes mempool chain resolution, cascade eviction, parent-mined transitions, reorg cycles, collision rejection, and boundary index stress tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4c619c1e4832eb49f51e06bb31180)