### PR TITLE
Expand CT production review with denomination-model risk assessment

### DIFF
--- a/docs/ct_master_review.md
+++ b/docs/ct_master_review.md
@@ -1,96 +1,95 @@
 # Confidential Transactions (Pubkey-Referenced Rings) Review vs Master
 
 Date: 2026-05-01
-Branch under review: `work`
-Head reviewed: `89b1950` (feature) + `154c2bb` (review artifact)
-Master baseline used: merge point `80c2bac` (explicit `Merge branch 'master' into dev/ct_15` in history).
+Branch under review: `work` (used as `dev/ct_17` equivalent in this checkout)
+Head reviewed: `f8c1b80`
+Master baseline used: `8fce081` (master parent in merge `80c2bac`)
 
 ## Executive summary
 
-- **Architecture direction is correct**: ring-member references by output pubkey are significantly more reorg-robust than global index references.
-- **Consensus safety posture is good**: block validation is chain-only (`allowMempool=false`), so mempool state cannot alter consensus decisions.
-- **Critical hardening needed (now implemented in this branch)**:
-  1. reject mempool pubkey-index collisions instead of silently overwriting,
-  2. widen mempool output index type from `uint16_t` to `uint32_t`.
-- **Remaining requirement before production**: targeted regression/integration tests for mempool chaining, cascade eviction, reorg transitions, and collision handling.
+- **Core direction is sound**: hidden amounts + Pedersen commitments + MLSAG + per-output GK membership proofs is a coherent CT design for a CryptoNote-derived chain.
+- **Production safety improved materially** on this branch by hardening pubkey-ring mempool resolution (collision rejection + wider mempool out index).
+- **Main residual production risk is economic/privacy policy, not cryptographic plumbing**: the fixed 64-denomination lattice leaks amount structure compared with full range proofs and pushes sub-floor residue into transparent change/fees.
+- **Verdict**: technically close, but **not yet “production-ready”** until denomination-side edge cases and policy/test coverage are closed.
 
-## Review method and coverage
+## Scope and method
 
-The following implementation areas were reviewed end-to-end:
+Compared `8fce081..f8c1b80` with focus on:
 
-1. **Transaction model and serialization**
-   - `ConfidentialInput` schema and wire encoding for pubkey-based ring members.
-2. **Core/consensus validation**
-   - ring invariants, binding of pubkey/commitment pairs, and signature sizing checks.
-3. **Blockchain storage/indexing**
-   - LMDB pubkey index lifecycle: insert, lookup, rollback/remove.
-4. **Mempool policy and dependency handling**
-   - pubkey fallback resolution, ancestor handling, and cascade removals.
-5. **Wallet construction/signing path**
-   - ring sorting and `realIndex` remapping before CT signing.
-6. **Explorer/RPC-facing CT fields**
-   - mixin and CT visibility touchpoints impacted by ring representation changes.
+1. CT transaction format/serialization and validation plumbing.
+2. Commitment/proof model for hidden amounts.
+3. Pubkey-referenced ring member resolution across chain + mempool.
+4. Wallet construction path and denomination decomposition behavior.
+5. Reorg/mempool safety properties.
 
-## Findings
+## What is strong
 
-### A) Consensus and chain validation: strong
+### 1) Consensus validation separation is correct
 
-- `ConfidentialInput` ring members are now pubkey-referenced and commitments are aligned by index.
-- Consensus checks validate ring non-emptiness, size consistency, and strict lexicographic ordering of pubkeys.
-- Signature vector sizing is validated against ring size.
-- Block-path CT validation remains chain-only (no mempool fallback), preserving deterministic consensus behavior.
+- Chain/block verification is deterministic and does not depend on mempool-only state.
+- CT ring member references by output pubkey avoid fragile global-index coupling and are better under reorg churn.
 
-### B) Storage/indexing: strong with clear rollback model
+### 2) Commitment and membership construction is internally consistent
 
-- LMDB pubkey index (`output_pubkey_idx`) provides stable output identity independent of global positional indexes.
-- Connect/disconnect paths include insertion/removal hooks for pubkey index entries.
+- Outputs carry Pedersen commitments and masked amounts.
+- GK proofs bind each commitment to one of exactly 64 canonical denominations (`GK_N = 64`), and prover-side checks enforce index/value consistency.
 
-### C) Mempool fallback/chaining: good design, two concrete hardening issues were present
+### 3) Recent mempool hardening addresses a real safety class
 
-#### C1) Collision policy in mempool pubkey index (**fixed in this branch**)
+- Duplicate pubkey collisions in mempool index are rejected (instead of silent overwrite).
+- Mempool CT output index widened to `uint32_t`, removing `uint16_t` truncation risk for resolver paths.
 
-Previous behavior: “last writer wins” overwrite in `m_pubkey_to_output`.
+## Critical review of the “allowed denomination set” model
 
-Risk: if duplicate output pubkeys appear in pool state, a dependent tx could resolve to wrong parent output.
+This is the key architectural tradeoff of this CT rollout.
 
-Fix implemented:
-- Duplicate pubkey inside same tx => reject.
-- Duplicate pubkey already indexed by different tx => reject.
-- On rejection, pool insertion is rolled back (spent-key-image insertions and tx indices removed).
+### A) Security correctness: acceptable
 
-#### C2) `uint16_t` output index in mempool lookup (**fixed in this branch**)
+Using a fixed denomination universe plus membership proof **does prove** outputs are in an allowed set and prevents arbitrary committed values. That gives strong anti-inflation structure when combined with balance checks and MLSAG spend authorization.
 
-Previous behavior: mempool output index was stored and returned as `uint16_t`.
+### B) Privacy leakage: materially higher than modern CT with range proofs
 
-Risk: potential truncation boundary at >65535 outputs.
+A 64-value set leaks value class information:
 
-Fix implemented:
-- Mempool pubkey index now stores `uint32_t` output index.
-- Lookup APIs updated accordingly.
-- CT resolver uses separate mempool index variable (`uint32_t`) and safe size checks.
+- Every output is known to be one of 64 exact amounts.
+- Multi-output composition patterns become statistically distinctive.
+- Repeated wallet decomposition heuristics can fingerprint payment behavior over time.
 
-## Files changed for fixes
+This is a **known tradeoff**, but it should be treated as product-level privacy debt vs Bulletproof-style range proofs.
 
-- `src/CryptoNoteCore/TransactionPool.h`
-- `src/CryptoNoteCore/TransactionPool.cpp`
-- `src/CryptoNoteCore/Blockchain.cpp`
+### C) Representability and UX/economic edge cases
 
-## Production readiness
+`MIN_CT_DENOMINATION = 0.01 KRB` (10^10 au) means any sub-floor remainder cannot be encoded as CT output.
 
-Current status after fixes:
-- **Consensus path**: acceptable.
-- **Mempool chaining policy**: materially improved and safer.
-- **Not yet production-ready until tests below pass**.
+Implications:
+- Wallets must either (1) keep transparent residue, or (2) burn residue into fee.
+- If decomposition/fallback policy is inconsistent across wallet/server versions, users can see confusing failures or privacy regressions.
+- Attackers can use dust-shaping around denomination boundaries to increase metadata leakage.
 
-## Required test plan before production
+### D) Supply/parameter rigidity risk
 
-1. **Mempool chain resolution**: A->B where B references A outputs via ring pubkeys.
-2. **Cascade eviction**: remove A and ensure B/C descendants are evicted in dependency order.
-3. **Parent mined transition**: mine A while B remains in pool; B revalidates via chain index.
-4. **Reorg cycle**: A mined -> reorg out -> back in; ensure resolver/index remains consistent.
-5. **Collision rejection**: inject or craft duplicate output pubkey attempts; verify deterministic rejection and rollback.
-6. **Boundary index test**: stress output indexing behavior with large output counts (policy/limits permitting).
+The denomination list is consensus-critical static data. Any later change is a hard-fork event requiring carefully orchestrated migration/testing. This is manageable, but should be explicitly documented as consensus surface.
+
+## Must-fix / must-prove before production
+
+1. **Add invariant tests for denomination decomposition and reconstruction**
+   - Property tests: representable amounts round-trip exactly.
+   - Explicit failure tests for non-representable sub-floor amounts.
+2. **Codify residue policy at consensus/tx-construction boundaries**
+   - One deterministic rule for “transparent change vs fee absorption.”
+3. **Adversarial mempool/reorg integration tests**
+   - A->B->C dependency chains, parent mined/unmined transitions, cascade eviction, duplicate pubkey rejection.
+4. **Document privacy envelope honestly**
+   - User-facing docs should state denomination-set leakage characteristics.
+5. **Capacity tests on large CT txs**
+   - Ensure verification cost and serialization limits are safe under worst-case output fanout.
 
 ## Final verdict
 
-The CT pubkey-referenced ring migration is directionally sound and addresses the core reorg fragility of index-referenced rings. With the implemented mempool collision/type fixes and the required regression suite, this implementation can move from integration-hardening to production candidacy.
+For the stated goal (bringing hidden amounts + MLSAG to a previously transparent-amount CryptoNote-like base), this implementation is **architecturally credible and substantially hardened**.
+
+However, because the denomination-set model introduces meaningful privacy/UX policy edges, and because these edges are consensus-adjacent in practice, I would rate current state as:
+
+- **Consensus cryptography/pathing**: near-ready.
+- **Operational and policy robustness**: needs one more hardening/testing cycle.
+- **Production readiness**: **Not yet**; likely ready after the above test/policy gates pass.


### PR DESCRIPTION
### Motivation
- Record a focused production-readiness review of the Confidential Transactions (CT) work and explicitly assess the security/privacy tradeoffs of the fixed 64-denomination commitment model so the project can track required hardening before production.

### Description
- Updated `docs/ct_master_review.md` to use `8fce081..f8c1b80` as the review range, add a clear analysis of the 64-denomination approach (privacy leakage, sub-floor residue implications, and hard-fork surface), and enumerate required production gates (decomposition invariants, residue policy, adversarial mempool/reorg tests, documentation, and capacity tests).

### Testing
- Ran repository inspection and verification commands including `rg --files -g 'AGENTS.md'`, `git branch --all`, `git show-ref --heads --tags`, `git log --oneline --decorate --graph --all`, `git diff --stat 8fce081..HEAD`, `rg -n 'denomination|canonical|ctProof|ct_proof|ctProofs|Confidential' src include`, and `git add`/`git commit`, and all of these commands completed successfully; no unit/integration test suite was executed as part of this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4ca4ad638832eb75ce095ec090fe3)